### PR TITLE
Modify install to get arm64 packages when appropriate

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -7,7 +7,8 @@ install_crictl() {
 	local install_type=$1
 	local version=$2
 	local install_path=$3
-	local platform="$(uname | tr '[:upper:]' '[:lower:]')-amd64"
+	local arch="$(uname -m)"
+	local platform="$(uname | tr '[:upper:]' '[:lower:]')-$(get_platform_code $arch)"
 	local bin_install_path="$install_path/bin"
 	local binary_path="$bin_install_path/crictl"
 	local download_url=$(get_download_url $version $platform)
@@ -44,6 +45,16 @@ get_download_url() {
 	local platform="$2"
 	local filename="$(get_filename $version $platform)"
 	echo "https://github.com/kubernetes-sigs/cri-tools/releases/download/v${version}/${filename}"
+}
+
+# This can be extended for all architectures shown here https://github.com/kubernetes-sigs/cri-tools/releases
+get_platform_code() {
+    case $1 in
+        'arm64') echo 'arm64';;
+        'aarch64') echo 'arm64';;
+        'amd64') echo 'amd64';;
+        'x86_86') echo 'amd64';;
+    esac
 }
 
 install_crictl $ASDF_INSTALL_TYPE $ASDF_INSTALL_VERSION $ASDF_INSTALL_PATH

--- a/bin/install
+++ b/bin/install
@@ -53,7 +53,7 @@ get_platform_code() {
         'arm64') echo 'arm64';;
         'aarch64') echo 'arm64';;
         'amd64') echo 'amd64';;
-        'x86_86') echo 'amd64';;
+        'x86_64') echo 'amd64';;
     esac
 }
 


### PR DESCRIPTION
This PR fixes #7 

## Checklist
* [x] I have signed the CLA => *No. Where is the CLA?*
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Allow asdf-crictl to install arm64 package versions as appropriate

### What changes did you make?
Changed hardcoded path to amd64 package to register if on amd/intel 64bit or arm 64bit platform

### What alternative solution should we consider, if any?
The structure of the `bin/install/get_platform_code()` function may not be as clean as it could be. Possibly update that